### PR TITLE
最新のvvakame/reviewイメージに追従する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM vvakame/review:latest
-RUN npm install -g npm && npm install -g @vivliostyle/cli
+RUN npm install -g @vivliostyle/cli
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       libatk-bridge2.0-0 libgtk-3-0 libasound2 && \
@@ -7,5 +7,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 # Patch for Linux+Docker+tmpfs issue
 COPY patches/ /tmp
-RUN cd /var/lib/gems/2.5.0/gems/review-5.1.1 && patch -p1 < /tmp/01preserve.patch && rm -r /tmp/*.patch
+RUN cd /var/lib/gems/3.1.0/gems/review-5.8.0 && patch -p1 < /tmp/01preserve.patch && rm -r /tmp/*.patch
 WORKDIR /work


### PR DESCRIPTION
- npmはvvakame/review内でバージョン指定されており、アップデートしようとすると以下のエラーが出るため、`npm install -g npm` は抜いています。
```
> [review 2/6] RUN npm install -g npm && npm install -g @vivliostyle/cli:
0.930 npm ERR! code EBADENGINE
0.931 npm ERR! engine Unsupported engine
0.931 npm ERR! engine Not compatible with your version of node/npm: npm@10.4.0
0.931 npm ERR! notsup Not compatible with your version of node/npm: npm@10.4.0
0.931 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
0.931 npm ERR! notsup Actual:   {"npm":"9.6.7","node":"v20.3.1"}
0.933 
0.933 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-02-04T13_55_35_175Z-debug-0.log
```

- RubyのバージョンとRe:VIEWのバージョンが最新のイメージとは異なっているため修正しています。